### PR TITLE
[BUGFIX] rename image caption text field on image-card module, text -…

### DIFF
--- a/theme/modules/image-card.module/fields.json
+++ b/theme/modules/image-card.module/fields.json
@@ -3884,9 +3884,9 @@
     "locked" : false,
     "children" : [ {
       "id" : "fa7871c9-06a6-2f77-7e8f-7a8a3137e1dc",
-      "name" : "text",
+      "name" : "rich_text",
       "display_width" : null,
-      "label" : "Text",
+      "label" : "Rich text",
       "required" : false,
       "locked" : false,
       "enabled_features" : [ "code_format", "subscript", "emoji", "underline", "superscript", "font_size", "link", "visual_blocks", "hr", "bold", "charmap", "italic", "personalize", "cta", "background_color", "anchor", "nonbreaking_space", "font_family", "text_color", "strikethrough", "alignment", "source_code" ],


### PR DESCRIPTION
…> rich_text

# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->

Changed the image caption text field name on the image-card module, from text to rich_text, to match the image macro.
