### PR TITLE
[BUGFIX] render dropdown current language item only if show_current_l…

### DIFF
--- a/theme/modules/site-header.module/module.html
+++ b/theme/modules/site-header.module/module.html
@@ -64,19 +64,19 @@
           </button>
 
           <ul role="list" class="dropdown-menu header-language__list">
-            <li class="header-language__list-item header-language__list-item--current">
-              <a class="header-language__list-item-link header-language__list-item-link--current hs-skip-lang-url-rewrite"
-              lang="{{content.language.languageTag}}" hreflang="{{content.language.languageTag}}"
-              href="{{content.absolute_url}}">
-                {% if module.language_switcher.dropdown.show_current_language %}
+            {% if module.language_switcher.dropdown.show_current_language %}
+              <li class="header-language__list-item header-language__list-item--current">
+                <a class="header-language__list-item-link header-language__list-item-link--current hs-skip-lang-url-rewrite"
+                  lang="{{content.language.languageTag}}" hreflang="{{content.language.languageTag}}"
+                  href="{{content.absolute_url}}">
                   {% if module.language_switcher.dropdown.show_language_code %}
                     {{content.language.languageTag|upper}}
                   {% else %}
                     {{locale_name(content.language)}}
                   {% endif %}
-                {% endif %}
-              </a>
-            </li>
+                </a>
+              </li>
+            {% endif %}
 
             {% for item in content.translated_content.values()|selectattr('published') %}
               {% if module.language_switcher.dropdown.show_language_code %}


### PR DESCRIPTION
…anguage

# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
Moved language switcher dropdown current item and link under the if statement so it will not render empty HTML tags