### PR TITLE
[BUGFIX] add textarea:placeholder styles so it editable same as inputs

### DIFF
--- a/theme/css/base/form-defaults.css
+++ b/theme/css/base/form-defaults.css
@@ -157,7 +157,8 @@
   color: var(--_form-error-color);
 }
 
-.form-default input::placeholder {
+.form-default input::placeholder,
+.form-default textarea::placeholder {
   color: var(--_form-placeholder-color);
 }
 

--- a/theme/css/global-theme-settings/forms.css
+++ b/theme/css/global-theme-settings/forms.css
@@ -132,7 +132,8 @@
   }
 {% endif %}
 
-.form-default input::placeholder {
+.form-default input::placeholder,
+.form-default textarea::placeholder {
   {% if theme.forms.placeholder.font.style %}
     {{theme.forms.placeholder.font.style}};
   {% endif %}


### PR DESCRIPTION
# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
Added textarea::placeholder to use the same default styling as input::placeholder. This should fix the next issue:
- when editing form styles tab and change placeholder font-size and color - the changes apply only for input's placeholders but not for textarea placeholders