### PR TITLE
[BUGFIX] blog-pagination - add wrapper to linktext in macro, update style selector

### DIFF
--- a/theme/modules/blog-pagination.module/module.html
+++ b/theme/modules/blog-pagination.module/module.html
@@ -19,7 +19,7 @@
     }
 
     @media (max-width: 575.98px) {
-      .pagination-module__link .hs_cos_wrapper_type_text {
+      .pagination-module__link .g-module-macros-link__text {
         display: none;
       }
     }

--- a/theme/modules/macros/link.html
+++ b/theme/modules/macros/link.html
@@ -158,7 +158,7 @@
             )}}
           {%- endif -%}
         {%- endif -%}
-        {{data.text}}
+        <span class="g-module-macros-link__text">{{data.text}}</span>
         {%- if data.icon.icon.name %}
           {%- if data.icon.icon_position == 'right' -%}
             {{icon_macros.render_icon_tmpl(data.icon, style.icon, global_data,


### PR DESCRIPTION
# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
Probably after code refactoring in the transition from nimbly -> nimbly-lite, the styling that hides the labels in the blog-pagination in mobile (to fit properly) stopped working again. A missing selector for the linktext in link macro made it impossible to fix just by updating the styling, so one has been added.