### PR TITLE
[BUGFIX] blog-list, blog-recent, blog-related: description field is stripped of html (like blog-recent-by-tag)

### DIFF
--- a/theme/modules/blog-list.module/module.html
+++ b/theme/modules/blog-list.module/module.html
@@ -293,7 +293,7 @@
 {# Description #}
 {%- macro render_description(content) -%}
   <div class="blog-listing-module__article-description blog-listing-module__article-item">
-    {%- set richtext_data = {"rich_text":content.post_list_content,"truncate":module.description.truncate}%}{{richtext_macros.render_richtext_tmpl(richtext_data, module.style.richtext, module)}}
+    {%- set richtext_data = {"rich_text":content.post_list_content,"truncate":module.description.truncate}%}{{richtext_macros.render_richtext_tmpl(richtext_data, module.style.richtext, module)|sanitize_html("STRIP")}}
   </div>
 {%- endmacro -%}
 

--- a/theme/modules/blog-recent.module/module.html
+++ b/theme/modules/blog-recent.module/module.html
@@ -293,7 +293,7 @@
 {# Description #}
 {%- macro render_description(content) -%}
   <div class="blog-recent-module__article-description blog-recent-module__article-item">
-    {%- set richtext_data = {"rich_text":content.post_list_content,"truncate":module.description.truncate}%}{{richtext_macros.render_richtext_tmpl(richtext_data, module.style.richtext, module)}}
+    {%- set richtext_data = {"rich_text":content.post_list_content,"truncate":module.description.truncate}%}{{richtext_macros.render_richtext_tmpl(richtext_data, module.style.richtext, module)|sanitize_html("STRIP")}}
   </div>
 {%- endmacro -%}
 

--- a/theme/modules/blog-related.module/module.html
+++ b/theme/modules/blog-related.module/module.html
@@ -280,7 +280,7 @@
 {# Description #}
 {%- macro render_description(content) -%}
   <div class="blog-related-module__article-description">
-    {%- set richtext_data = {"rich_text":content.post_list_content,"truncate":module.description.truncate}%}{{richtext_macros.render_richtext_tmpl(richtext_data, module.style.richtext, module)}}
+    {%- set richtext_data = {"rich_text":content.post_list_content,"truncate":module.description.truncate}%}{{richtext_macros.render_richtext_tmpl(richtext_data, module.style.richtext, module)|sanitize_html("STRIP")}}
   </div>
 {%- endmacro -%}
 


### PR DESCRIPTION
Makes description field in blog modules useful again. :)

# New Pull Request checklist

## Please check if your PR fulfills the following requirements

- [x] Contributing: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md>
- [x] Coding Rules: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#coding-rules>
- [x] Commit message conventions: <https://github.com/resultify/.github/blob/master/CONTRIBUTING.md#commit-message-guidelines>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] [FEATURE] - A new feature
- [x] [BUGFIX] - A bug fix
- [ ] [TASK] - Any task, which is not a **new feature** or **bugfix**
- [ ] [TEST] - Adding missing tests
- [ ] [DOC] - Documentation only changes
- [ ] [WIP] - Work in progress tag, should not be present when creating pull requests

## Breaking change

Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x" inside brackets -->

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please add a [!!!] label at the beginning of the commit message. -->
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Issue references

Issue Number: #...

## Description
<!-- Please add a context and reasoning around your changes, to help us merge quickly. -->
